### PR TITLE
Fix export in "Usage" code blocks

### DIFF
--- a/src/components/PluginUsage/index.jsx
+++ b/src/components/PluginUsage/index.jsx
@@ -9,7 +9,7 @@ function BasicPluginUsage(props) {
     <CodeBlock
       language="js"
       title="svgo.config.js">
-      {`module.export = {\n  plugins: [\n    "${props.pluginId}"\n  ]\n}`}
+      {`module.exports = {\n  plugins: [\n    "${props.pluginId}"\n  ]\n}`}
     </CodeBlock>
   );
 };
@@ -37,7 +37,7 @@ export default function PluginUsage() {
           <CodeBlock
             language="js"
             title="svgo.config.js">
-            {`module.export = {\n  plugins: [\n    {\n      name: "${pluginId}",\n      params: {\n${paramsTemplate}\n      }\n    }\n  ]\n}`}
+            {`module.exports = {\n  plugins: [\n    {\n      name: "${pluginId}",\n      params: {\n${paramsTemplate}\n      }\n    }\n  ]\n}`}
           </CodeBlock>
         </TabItem>
       )}


### PR DESCRIPTION
The example configuration objects on [svgo.dev](https://svgo.dev/) assign to `module.export`, instead of the standard `module.exports`. Copying the example usage as-is causes the configuration to be silently ignored.

This commit updates `module.export` to `module.exports`.