### PR TITLE
fix: add explicit ascent override on nimbus sans typeface

### DIFF
--- a/src/components/SvgoPreview/index.module.css
+++ b/src/components/SvgoPreview/index.module.css
@@ -1,5 +1,5 @@
 .profit {
-  font-family: var(--svgo-font-mono);
+  font-family: var(--ifm-font-family-monospace);
 }
 
 .highlight {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,6 +1,4 @@
 :root {
-  --svgo-font-mono: 'Liberation Mono', Monaco, Cousine, Consolas, monospace;
-  --svgo-font-sans: 'Nimbus Sans', Helvetica, Arial, Roboto, 'Liberation Sans', 'DejaVu Sans', Arimo, sans-serif;
   --svgo-global-width: 1200px;
   --svgo-pill-bg-color: #cbe2f9;
   --svgo-pill-fg-color: #0b5cad;
@@ -23,7 +21,6 @@
   --ifm-spacing-horizontal: 1rem;
   --search-local-hit-background: var(--svgo-sec-bg-color);
 
-  font-family: var(--svgo-font-sans);
   color: var(--svgo-pri-fg-color);
 }
 
@@ -48,9 +45,8 @@
 .button {
   --ifm-button-color: var(--svgo-pri-bg-color);
   --ifm-button-background-color: var(--svgo-pri-fg-color);
-  --ifm-button-border-color: var(--svgo-pri-fg-color);
 }
-.button:hover {
+.button:hover, .button:focus {
   --ifm-button-background-color: var(--svgo-button-hover-background-color);
 }
 
@@ -75,7 +71,7 @@
 nav input {
   background-color: var(--svgo-search-bg-color) !important;
 }
-nav input:hover {
+nav input:hover, nav input:focus {
   background-color: var(--svgo-search-bg-hover) !important;
 }
 nav div kbd {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -27,7 +27,7 @@ function HomepageHeader() {
             SVGO and its various integrations will enable you to optimize
             SVGs and serve your web applications faster.
           </p>
-          <div className={styles.buttons}>
+          <div>
             <Link
               className="button button--lg"
               to="/docs/introduction">

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -80,7 +80,7 @@
   display: inline-flex;
   align-items: center;
   user-select: none;
-  font-family: var(--svgo-font-mono);
+  font-family: var(--ifm-font-family-monospace);
   cursor: copy;
 }
 


### PR DESCRIPTION
## Font Face Alignment

On Chromium browsers, Nimbus Sans was not vertically aligned properly. This appears to be a due to a difference in how Firefox and Chromium handles fonts with different ascents/descent.

Here is how Chromium/Linux looked when Nimbus Sans was available:

![The text in the "Get Started" button is clearly not vertically centered within the height of the button.](https://github.com/svg/svgo.dev/assets/22801583/1a0a5903-fdd4-4397-a64f-a9b8e8bf8b78)

I was able to resolve this by setting an explicit `ascent-override`, however I later found that the theme Docusaurus ships by default already uses a reasonable local font stack. I opted to remove our font stack altogether and use the predefined `--ifm-font-family-*`, which also resolves the issue. 

Here is how it looks now on Chromium/Linux:

![The text in the "Get Started" button is now correctly aligned.](https://github.com/svg/svgo.dev/assets/22801583/9d333d95-138b-40b1-b277-83cc04ca396e)


## Accessibility

In some areas of the site, I forget to also style on `:focus` as well as `:hover` for uses that navigate the web with tab or other assistive technologies.

## Redundant Classes

Just removes the `buttons` class which was no longer in use.