### PR TITLE
chore: add param to workflow_dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@ on:
     types:
       - 'published'
   workflow_dispatch:
+    input:
+      svgoVersion:
+        description: The svg/svgo branch or tag to pull docs from.
+        default: 'main'
+        type: string
 
 permissions:
   contents: write
@@ -19,9 +24,10 @@ jobs:
         with:
           repository: svg/svgo
           path: .svgo
+          ref: ${{ inputs.svgoVersion }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn run build


### PR DESCRIPTION
Adds a parameter so we can continue to deploy the documentation for older versions of SVGO while working on newer ones. (This is useful when we've made changes in this repository, not svg/svgo, that we want to deploy, but don't want to pull the latest documentation.)

Until now, we'd always deployed `svg/svgo#main`, even though `main` may include things that doesn't apply to the latest official release. Now we can specify exactly which version we want to deploy.

Also updates the deploy task to use Node.js v20, which was missed in the previous PR.