### PR TITLE
chore: fix typo in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     types:
       - 'published'
   workflow_dispatch:
-    input:
+    inputs:
       svgoVersion:
         description: The svg/svgo branch or tag to pull docs from.
         default: 'main'


### PR DESCRIPTION
Smhsmh, missed an `s`. ^-^'

### Related

* Mistake introduced in https://github.com/svg/svgo.dev/pull/17