### PR TITLE
fix: search modal colors

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -11,13 +11,12 @@
   --svgo-logo-fg-color: #1d1d1b;
   --svgo-button-hover-background-color: #1b4055;
   --ifm-background-color: var(--svgo-pri-bg-color) !important;
-  --ifm-card-background-color: var(--svgo-sec-bg-color);
   --ifm-code-font-size: 95%;
   --ifm-color-primary: #216be2;
   --ifm-container-width-xl: var(--svgo-global-width);
   --ifm-footer-padding-horizontal: 1rem;
   --ifm-navbar-background-color: var(--svgo-pri-bg-color);
-  --ifm-navbar-shadow: 0 1rem 1rem 0 #0a1e291a;
+  --ifm-navbar-shadow: 0 .5rem .5rem 0 #0a1e291a;
   --ifm-spacing-horizontal: 1rem;
   --search-local-hit-background: var(--svgo-sec-bg-color);
 
@@ -32,12 +31,12 @@
     --svgo-pri-fg-color: #fff;
     --svgo-search-bg-color: #5a6a74;
     --svgo-search-bg-hover: #647682;
-    --svgo-sec-bg-color: #1c262d;
+    --svgo-sec-bg-color: #1b3241;
     --svgo-tir-bg-color: #5a6a74;
     --svgo-logo-fg-color: #fff;
     --svgo-button-hover-background-color: #e6e6e6;
-    --ifm-color-primary: #66b5ff;
-    --ifm-navbar-shadow: 0 1rem 1rem 0 #0a1e29;
+    --ifm-color-primary: #389fff;
+    --ifm-navbar-shadow: 0 .5rem .5rem 0 #0a1e29;
   }
 }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -31,7 +31,7 @@ function HomepageHeader() {
             <Link
               className="button button--lg"
               to="/docs/introduction">
-              Get Started
+              Read the docs
             </Link>
           </div>
           <div className={clsx(styles.installInstructions)} onClick={onClick}>

--- a/src/theme/DocRoot/Layout/Sidebar/styles.module.css
+++ b/src/theme/DocRoot/Layout/Sidebar/styles.module.css
@@ -11,7 +11,7 @@
   .docSidebarContainer {
     display: block;
     width: var(--doc-sidebar-width);
-    margin-top: calc(-1 * var(--ifm-navbar-height));
+    margin-top: calc(-1 * var(--ifm-navbar-height) + .5rem);
     clip-path: inset(0);
   }
 


### PR DESCRIPTION
Some general amendments to the website:

* Makes the documentation sidebar inline with the table of contents.
* Reduces the shadow in the navbar so it doesn't overlap with the documentation.
* Changes the colors of the search modal to be more cohesive with the rest of the site.
* Change the "Getting Started" button to "Read the docs", so it's clearer that both take the user to the same page.