### PR TITLE
chores: update code block prism theme

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -166,8 +166,8 @@ const config = {
       ],
     },
     prism: {
-      theme: themes.github,
-      darkTheme: themes.dracula
+      theme: themes.vsLight,
+      darkTheme: themes.oneDark
     },
     footer: {
       links: [

--- a/src/components/PluginParams/index.jsx
+++ b/src/components/PluginParams/index.jsx
@@ -21,8 +21,7 @@ export default function PluginParams() {
           <dt>
             <code>{param.name}</code>
           </dt>
-          <dd className={clsx(styles.leftMargin)}>
-            <p dangerouslySetInnerHTML={{__html: param.description}}></p>
+          <dd className={clsx(styles.leftMargin)} dangerouslySetInnerHTML={{__html: param.description}}>
           </dd>
         </Fragment>
       ))}


### PR DESCRIPTION
* Remove the redundant `<p>` tag that was being inserted in the `PluginParams` component. In practice, it was doing `dd p p` before, now it'll just do `dd p`.
* Change the Prism theme of the code blocks.