### PR TITLE
fix: remove eager scrolling on docs sidebar

### DIFF
--- a/src/theme/DocRoot/Layout/Sidebar/styles.module.css
+++ b/src/theme/DocRoot/Layout/Sidebar/styles.module.css
@@ -21,7 +21,7 @@
   }
 
   .sidebarViewport {
-    top: 0;
+    top: .5rem;
     position: sticky;
     height: 100%;
     max-height: 100vh;


### PR DESCRIPTION
If there was enough content that it could be scrolled, we sometimes scrolled the sidebar when we didn't want to.

Fixes the CSS so that it no longer happens.