### PR TITLE
chore: use preact instead of react

### DIFF
--- a/.yarn/patches/@docusaurus-react-loadable-npm-6.0.0-75f0ebc146.patch
+++ b/.yarn/patches/@docusaurus-react-loadable-npm-6.0.0-75f0ebc146.patch
@@ -1,0 +1,17 @@
+diff --git a/lib/index.js b/lib/index.js
+index 1167aa26f6ad3cbacde07230386a54270e0bcdb9..0433a0c3b4d63fb2d3caf7b5165f9e4028b23383 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -179,12 +179,6 @@ function createLoadableComponent(loadFn, options) {
+     _proto._loadModule = function _loadModule() {
+       var _this2 = this;
+ 
+-      if (this.context && Array.isArray(opts.modules)) {
+-        opts.modules.forEach(function (moduleName) {
+-          _this2.context.report(moduleName);
+-        });
+-      }
+-
+       if (!res.loading) {
+         return;
+       }

--- a/.yarn/patches/@easyops-cn-autocomplete.js-npm-0.38.1-2375cf670a.patch
+++ b/.yarn/patches/@easyops-cn-autocomplete.js-npm-0.38.1-2375cf670a.patch
@@ -1,0 +1,56 @@
+diff --git a/dist/autocomplete.js b/dist/autocomplete.js
+index 7d0bc04b429024372bf36dbd1560440d06f5d859..3d185d39765633ee20ddb4801a2f592d9be2c69e 100644
+--- a/dist/autocomplete.js
++++ b/dist/autocomplete.js
+@@ -1165,7 +1165,6 @@ return /******/ (function(modules) { // webpackBootstrap
+ 	      var callback  = delegator || fn
+ 	      handler.proxy = function(e){
+ 	        e = compatible(e)
+-	        if (e.isImmediatePropagationStopped()) return
+ 	        try {
+ 	          var dataPropDescriptor = Object.getOwnPropertyDescriptor(e, 'data')
+ 	          if (!dataPropDescriptor || dataPropDescriptor.writable)
+@@ -1227,7 +1226,6 @@ return /******/ (function(modules) { // webpackBootstrap
+ 	      ignoreProperties = /^([A-Z]|returnValue$|layer[XY]$|webkitMovement[XY]$)/,
+ 	      eventMethods = {
+ 	        preventDefault: 'isDefaultPrevented',
+-	        stopImmediatePropagation: 'isImmediatePropagationStopped',
+ 	        stopPropagation: 'isPropagationStopped'
+ 	      }
+ 
+@@ -1354,7 +1352,6 @@ return /******/ (function(modules) { // webpackBootstrap
+ 	      e.target = element
+ 	      $.each(findHandlers(element, event.type || event), function(i, handler){
+ 	        result = handler.proxy(e)
+-	        if (e.isImmediatePropagationStopped()) return false
+ 	      })
+ 	    })
+ 	    return result
+diff --git a/zepto.js b/zepto.js
+index 390e5ca0ef4b36a8d3955965432c5c06be8ae9c9..dcb73d39266342646b8a04b37b4033bb5ae0e53e 100644
+--- a/zepto.js
++++ b/zepto.js
+@@ -998,7 +998,6 @@
+       var callback  = delegator || fn
+       handler.proxy = function(e){
+         e = compatible(e)
+-        if (e.isImmediatePropagationStopped()) return
+         try {
+           var dataPropDescriptor = Object.getOwnPropertyDescriptor(e, 'data')
+           if (!dataPropDescriptor || dataPropDescriptor.writable)
+@@ -1060,7 +1059,6 @@
+       ignoreProperties = /^([A-Z]|returnValue$|layer[XY]$|webkitMovement[XY]$)/,
+       eventMethods = {
+         preventDefault: 'isDefaultPrevented',
+-        stopImmediatePropagation: 'isImmediatePropagationStopped',
+         stopPropagation: 'isPropagationStopped'
+       }
+ 
+@@ -1187,7 +1185,6 @@
+       e.target = element
+       $.each(findHandlers(element, event.type || event), function(i, handler){
+         result = handler.proxy(e)
+-        if (e.isImmediatePropagationStopped()) return false
+       })
+     })
+     return result

--- a/docusaurus.config.mjs
+++ b/docusaurus.config.mjs
@@ -192,6 +192,7 @@ const config = {
     ['@docusaurus/plugin-sitemap', pluginSitemapOptions],
     ['@docusaurus/plugin-svgr', pluginSvgrOptions],
     './src/plugins/prefers-color-scheme.js',
+    './src/plugins/preact.js',
   ],
   themes: [
     '@docusaurus/theme-live-codeblock',

--- a/package.json
+++ b/package.json
@@ -59,10 +59,13 @@
     "@docusaurus/theme-live-codeblock": "3.8.1",
     "@easyops-cn/docusaurus-search-local": "^0.51.1",
     "@mdx-js/react": "^3.1.0",
+    "@preact/compat": "^18.3.1",
     "clsx": "^2.1.1",
+    "preact": "^10.26.9",
+    "preact-render-to-string": "^6.5.13",
     "prism-react-renderer": "^2.4.1",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
+    "react": "npm:@preact/compat@*",
+    "react-dom": "npm:@preact/compat@*",
     "rehype-stringify": "^10.0.1",
     "svgo": "^4.0.0"
   },
@@ -70,11 +73,14 @@
     "@docusaurus/module-type-aliases": "3.8.1",
     "@docusaurus/types": "3.8.1",
     "@eslint/js": "^9.30.0",
-    "@types/react": "^19.1.8",
     "eslint": "^9.30.0",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^16.2.0",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3"
+  },
+  "resolutions": {
+    "@easyops-cn/autocomplete.js@npm:^0.38.1": "patch:@easyops-cn/autocomplete.js@npm%3A0.38.1#~/.yarn/patches/@easyops-cn-autocomplete.js-npm-0.38.1-2375cf670a.patch",
+    "react-loadable": "patch:@docusaurus/react-loadable@npm%3A6.0.0#~/.yarn/patches/@docusaurus-react-loadable-npm-6.0.0-75f0ebc146.patch"
   }
 }

--- a/src/components/DefaultBadge/index.jsx
+++ b/src/components/DefaultBadge/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import styles from './index.module.css';
 
 export default function DefaultBadge() {

--- a/src/components/HomepageFeatures/index.jsx
+++ b/src/components/HomepageFeatures/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import clsx from 'clsx';
 import styles from './index.module.css';
 import SvgoHackerman from '../../vectors/svgo_hackerman.svg';
@@ -40,11 +40,11 @@ const FeatureList = [
 
 /**
  * @param {{
- *   Svg: React.ComponentType<React.SVGProps<SVGSVGElement>>,
+ *   Svg: React.ComponentType<React.SVGProps<SVGSVGElement> & { title?: string }>,
  *   title: string,
- *   description: import('react').JSX.Element
+ *   description: import('preact/compat').JSX.Element
  * }} param0
- * @returns {import('react').JSX.Element}
+ * @returns {import('preact/compat').JSX.Element}
  */
 function Feature({ Svg, title, description }) {
   return (

--- a/src/components/PluginDemo/index.jsx
+++ b/src/components/PluginDemo/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';
 import CodeBlock from '@theme/CodeBlock';
 

--- a/src/components/PluginParams/index.jsx
+++ b/src/components/PluginParams/index.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment } from 'preact/compat';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';
 import styles from './index.module.css';
 

--- a/src/components/PluginUsage/index.jsx
+++ b/src/components/PluginUsage/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/src/components/SvgDemo/index.jsx
+++ b/src/components/SvgDemo/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState } from 'preact/compat';
 import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/src/components/SvgoPreview/index.jsx
+++ b/src/components/SvgoPreview/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import { optimize } from 'svgo/browser';
 import SvgPreview from '../SvgDemo';
 import styles from './index.module.css';
@@ -11,7 +11,7 @@ import styles from './index.module.css';
 
 /**
  * @param {SvgoPreviewProps} props
- * @returns {import('react').JSX.Element}
+ * @returns {import('preact/compat').JSX.Element}
  */
 export default function SvgoPreview(props) {
   const { svg, svgoConfig } = props;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';

--- a/src/plugins/preact.js
+++ b/src/plugins/preact.js
@@ -1,0 +1,21 @@
+function preact() {
+  return {
+    name: 'preact',
+    configureWebpack(config) {
+      const alias = config?.resolve?.alias ?? {};
+      alias['react'] = 'preact/compat';
+      alias['react-dom/test-utils'] = 'preact/test-utils';
+      alias['react-dom'] = 'preact/compat';
+      alias['react/jsx-runtime'] = 'preact/jsx-runtime';
+
+      return {
+        mergeStrategy: {
+          'resolve.alias': 'replace'
+        },
+        resolve: { alias }
+      };
+    }
+  };
+}
+
+module.exports = preact;

--- a/src/theme/DocItem/Content/index.js
+++ b/src/theme/DocItem/Content/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import clsx from 'clsx';
 import { ThemeClassNames } from '@docusaurus/theme-common';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';

--- a/src/theme/DocItem/Footer/index.js
+++ b/src/theme/DocItem/Footer/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import clsx from 'clsx';
 import { ThemeClassNames } from '@docusaurus/theme-common';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import clsx from 'clsx';
 import DocItemPaginator from '@theme/DocItem/Paginator';
 import DocItemFooter from '@theme/DocItem/Footer';

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import { HtmlClassNameProvider } from '@docusaurus/theme-common';
 import { DocProvider } from '@docusaurus/plugin-content-docs/client';
 import DocItemMetadata from '@theme/DocItem/Metadata';

--- a/src/theme/DocRoot/Layout/Main/index.js
+++ b/src/theme/DocRoot/Layout/Main/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import clsx from 'clsx';
 import { useDocsSidebar } from '@docusaurus/plugin-content-docs/client';
 import styles from './styles.module.css';

--- a/src/theme/DocRoot/Layout/Sidebar/ExpandButton/index.js
+++ b/src/theme/DocRoot/Layout/Sidebar/ExpandButton/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import { translate } from '@docusaurus/Translate';
 import IconArrow from '@theme/Icon/Arrow';
 import styles from './styles.module.css';

--- a/src/theme/DocRoot/Layout/Sidebar/index.js
+++ b/src/theme/DocRoot/Layout/Sidebar/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'preact/compat';
 import clsx from 'clsx';
 import { prefersReducedMotion, ThemeClassNames } from '@docusaurus/theme-common';
 import { useDocsSidebar } from '@docusaurus/plugin-content-docs/client';

--- a/src/theme/DocRoot/Layout/index.js
+++ b/src/theme/DocRoot/Layout/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState } from 'preact/compat';
 import { useDocsSidebar } from '@docusaurus/plugin-content-docs/client';
 import BackToTopButton from '@theme/BackToTopButton';
 import DocRootLayoutSidebar from '@theme/DocRoot/Layout/Sidebar';

--- a/src/theme/Footer/Copyright/index.js
+++ b/src/theme/Footer/Copyright/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 
 export default function FooterCopyright({ copyright }) {
   return (

--- a/src/theme/Footer/Layout/index.js
+++ b/src/theme/Footer/Layout/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import clsx from 'clsx';
 import styles from './index.module.css';
 

--- a/src/theme/Footer/LinkItem/index.js
+++ b/src/theme/Footer/LinkItem/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import isInternalUrl from '@docusaurus/isInternalUrl';

--- a/src/theme/Footer/Links/MultiColumn/index.js
+++ b/src/theme/Footer/Links/MultiColumn/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import LinkItem from '@theme/Footer/LinkItem';
 import clsx from 'clsx';
 import styles from './index.module.css';

--- a/src/theme/Footer/Links/Simple/index.js
+++ b/src/theme/Footer/Links/Simple/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import LinkItem from '@theme/Footer/LinkItem';
 
 function Separator() {

--- a/src/theme/Footer/Links/index.js
+++ b/src/theme/Footer/Links/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import { isMultiColumnFooterLinks } from '@docusaurus/theme-common';
 import FooterLinksMultiColumn from '@theme/Footer/Links/MultiColumn';
 import FooterLinksSimple from '@theme/Footer/Links/Simple';

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import { useThemeConfig } from '@docusaurus/theme-common';
 import FooterLinks from '@theme/Footer/Links';
 import FooterLogo from '@theme/Footer/Logo';

--- a/src/theme/Navbar/Logo/index.js
+++ b/src/theme/Navbar/Logo/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'preact/compat';
 import Link from '@docusaurus/Link';
 import styles from './index.module.css';
 import Logo from '../../../vectors/logo.svg';

--- a/src/theme/TOCItems/Tree.js
+++ b/src/theme/TOCItems/Tree.js
@@ -1,5 +1,5 @@
+import React from 'preact/compat';
 import clsx from 'clsx';
-import React from 'react';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';
 import Translate from '@docusaurus/Translate';
 import styles from './index.module.css';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,12 @@
     "noImplicitAny": false,
     "jsx": "preserve",
     "skipLibCheck": true,
+    "paths": {
+      "react": ["./node_modules/preact/compat/"],
+      "react/jsx-runtime": ["./node_modules/preact/jsx-runtime"],
+      "react-dom": ["./node_modules/preact/compat/"],
+      "react-dom/*": ["./node_modules/preact/compat/*"]
+    }
   },
   "exclude": [
     ".docusaurus/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,6 +2108,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@docusaurus/react-loadable@npm:6.0.0":
+  version: 6.0.0
+  resolution: "@docusaurus/react-loadable@npm:6.0.0"
+  dependencies:
+    "@types/react": "npm:*"
+  peerDependencies:
+    react: "*"
+  checksum: 10/f7cca3dbc16403c426a6ab843210937caab0ea9b3880b4dee7923ebb55ff5dbbac2110ffd7d241894deab07dd74a2e18df3ed2509111036f24ac8dedb5ec92c2
+  languageName: node
+  linkType: hard
+
 "@docusaurus/theme-classic@npm:3.8.1":
   version: 3.8.1
   resolution: "@docusaurus/theme-classic@npm:3.8.1"
@@ -2274,13 +2285,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@easyops-cn/autocomplete.js@npm:^0.38.1":
+"@easyops-cn/autocomplete.js@npm:0.38.1":
   version: 0.38.1
   resolution: "@easyops-cn/autocomplete.js@npm:0.38.1"
   dependencies:
     cssesc: "npm:^3.0.0"
     immediate: "npm:^3.2.3"
   checksum: 10/40a053d7fba2532c5ec2e6e070afe1f6d610d355db3c1ab0682a7d80eef1d95ca3b0ff6a42fc3de6c90537626a428a41b439207ea81490b78eb83a14fd514bec
+  languageName: node
+  linkType: hard
+
+"@easyops-cn/autocomplete.js@patch:@easyops-cn/autocomplete.js@npm%3A0.38.1#~/.yarn/patches/@easyops-cn-autocomplete.js-npm-0.38.1-2375cf670a.patch":
+  version: 0.38.1
+  resolution: "@easyops-cn/autocomplete.js@patch:@easyops-cn/autocomplete.js@npm%3A0.38.1#~/.yarn/patches/@easyops-cn-autocomplete.js-npm-0.38.1-2375cf670a.patch::version=0.38.1&hash=a6643f"
+  dependencies:
+    cssesc: "npm:^3.0.0"
+    immediate: "npm:^3.2.3"
+  checksum: 10/a50cc5cfe72de9a65b0a3f1324bcf937efc2745dff9478191cd33f759192fd34954c2deb4ef4ecfb42bfdcd519e11a747dcd284716ba025a8dea2d0926e16cb5
   languageName: node
   linkType: hard
 
@@ -2840,6 +2861,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@preact/compat@npm:^18.3.1, react-dom@npm:@preact/compat@*, react@npm:@preact/compat@*":
+  version: 18.3.1
+  resolution: "@preact/compat@npm:18.3.1"
+  peerDependencies:
+    preact: "*"
+  checksum: 10/c3a457a5496672207a276f89961ae725ca811c42a37865bac66fe636473805ac4bf6bcf333b2745fe4da874ccd8a5293020a5b353b027bc532ca74b3610dac37
+  languageName: node
+  linkType: hard
+
 "@sideway/address@npm:^4.1.3":
   version: 4.1.4
   resolution: "@sideway/address@npm:4.1.4"
@@ -3376,7 +3406,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:^19.1.8":
+"@types/react@npm:*":
   version: 19.1.8
   resolution: "@types/react@npm:19.1.8"
   dependencies:
@@ -11091,6 +11121,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"preact-render-to-string@npm:^6.5.13":
+  version: 6.5.13
+  resolution: "preact-render-to-string@npm:6.5.13"
+  peerDependencies:
+    preact: ">=10"
+  checksum: 10/1c8bc23ca618c383ee95e123828cbe31a83ff43dc9b815500a57dd3ff28054988fa94d3a465608cf26bc6b1d3bd9de44683099b8ca411a2e45244ed1901a158f
+  languageName: node
+  linkType: hard
+
+"preact@npm:^10.26.9":
+  version: 10.26.9
+  resolution: "preact@npm:10.26.9"
+  checksum: 10/277da0b5fea5dbf5445244b90cbf5cdca4e80cad85a681910754bb743e6a91db54dc4846d66db8877183a7c31ddf6f184ec53ba6841d2a57edbed32313c95770
+  languageName: node
+  linkType: hard
+
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
@@ -11298,17 +11344,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^19.1.0":
-  version: 19.1.0
-  resolution: "react-dom@npm:19.1.0"
-  dependencies:
-    scheduler: "npm:^0.26.0"
-  peerDependencies:
-    react: ^19.1.0
-  checksum: 10/c5b58605862c7b0bb044416b01c73647bb8e89717fb5d7a2c279b11815fb7b49b619fe685c404e59f55eb52c66831236cc565c25ee1c2d042739f4a2cc538aa2
-  languageName: node
-  linkType: hard
-
 "react-fast-compare@npm:^3.2.0":
   version: 3.2.2
   resolution: "react-fast-compare@npm:3.2.2"
@@ -11365,14 +11400,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-loadable@npm:@docusaurus/react-loadable@6.0.0":
+"react-loadable@patch:@docusaurus/react-loadable@npm%3A6.0.0#~/.yarn/patches/@docusaurus-react-loadable-npm-6.0.0-75f0ebc146.patch":
   version: 6.0.0
-  resolution: "@docusaurus/react-loadable@npm:6.0.0"
+  resolution: "react-loadable@patch:@docusaurus/react-loadable@npm%3A6.0.0#~/.yarn/patches/@docusaurus-react-loadable-npm-6.0.0-75f0ebc146.patch::version=6.0.0&hash=4c1c52"
   dependencies:
     "@types/react": "npm:*"
   peerDependencies:
     react: "*"
-  checksum: 10/f7cca3dbc16403c426a6ab843210937caab0ea9b3880b4dee7923ebb55ff5dbbac2110ffd7d241894deab07dd74a2e18df3ed2509111036f24ac8dedb5ec92c2
+  checksum: 10/7376fd4a9edebcadb55304cb050c70045d86f09502a8d11d6a1f77e8636a6f23ad7554569a8c461db30d95542cce85f4cebbc8e1f659328aff2617702343605c
   languageName: node
   linkType: hard
 
@@ -11421,13 +11456,6 @@ __metadata:
   peerDependencies:
     react: ">=15"
   checksum: 10/99d54a99af6bc6d7cad2e5ea7eee9485b62a8b8e16a1182b18daa7fad7dafa5e526850eaeebff629848b297ae055a9cb5b4aba8760e81af8b903efc049d48f5c
-  languageName: node
-  linkType: hard
-
-"react@npm:^19.1.0":
-  version: 19.1.0
-  resolution: "react@npm:19.1.0"
-  checksum: 10/d0180689826fd9de87e839c365f6f361c561daea397d61d724687cae88f432a307d1c0f53a0ee95ddbe3352c10dac41d7ff1ad85530fb24951b27a39e5398db4
   languageName: node
   linkType: hard
 
@@ -11978,13 +12006,6 @@ __metadata:
   version: 1.4.1
   resolution: "sax@npm:1.4.1"
   checksum: 10/b1c784b545019187b53a0c28edb4f6314951c971e2963a69739c6ce222bfbc767e54d320e689352daba79b7d5e06d22b5d7113b99336219d6e93718e2f99d335
-  languageName: node
-  linkType: hard
-
-"scheduler@npm:^0.26.0":
-  version: 0.26.0
-  resolution: "scheduler@npm:0.26.0"
-  checksum: 10/1ecf2e5d7de1a7a132796834afe14a2d589ba7e437615bd8c06f3e0786a3ac3434655e67aac8755d9b14e05754c177e49c064261de2673aaa3c926bc98caa002
   languageName: node
   linkType: hard
 
@@ -12806,14 +12827,16 @@ __metadata:
     "@easyops-cn/docusaurus-search-local": "npm:^0.51.1"
     "@eslint/js": "npm:^9.30.0"
     "@mdx-js/react": "npm:^3.1.0"
-    "@types/react": "npm:^19.1.8"
+    "@preact/compat": "npm:^18.3.1"
     clsx: "npm:^2.1.1"
     eslint: "npm:^9.30.0"
     eslint-plugin-react: "npm:^7.37.5"
     globals: "npm:^16.2.0"
+    preact: "npm:^10.26.9"
+    preact-render-to-string: "npm:^6.5.13"
     prism-react-renderer: "npm:^2.4.1"
-    react: "npm:^19.1.0"
-    react-dom: "npm:^19.1.0"
+    react: "npm:@preact/compat@*"
+    react-dom: "npm:@preact/compat@*"
     rehype-stringify: "npm:^10.0.1"
     rimraf: "npm:^6.0.1"
     svgo: "npm:^4.0.0"


### PR DESCRIPTION
Migrate from React to Preact.

We don't need most of the advanced features of React, so we can switch it out for Preact. A much lighter implementation, with largely an identical API.

This change alone reduces the JS bundle by 157.63~ KB, and to the best of my knowledge and testing, preserves all features we're utilizing.

* Site itself still works, docs, search, etc.
* Website still works without JavaScript.

## Changes

* We'll depend on and import Preact instead of React now. (Though in the short-term making heavy use of `preact/compat`.
* We defined a Docusaurus plugin to add some webpack aliases to redirect imports of `react` to `preact`.

## Metrics

| | Before (React) | After (Preact) |
|---|---|---|
| Landing page (uncompressed resources) | 997.98 kB | 840.35 kB |
| First page of docs (uncompressed resources) | 1.50 MB | 1.34 MB |

## Workarounds

### SSR Broke

After migrating to Preact, SSR broke! :scream:

We're not sure why, but one of the maintainers of Preact investigated and found that if we patch out a few lines of code from `@docusaurus-react-loadable`, things magically start to work.

> … but once you've gotten `react` fully out of `node_modules`, you should just need to comment out line `183` of `node_modules/react-loadable/lib/index.js` -- no idea why that fails, or why that module is even needed today, but builds do seem to work once that's corrected.
> 
> — https://github.com/preactjs/preact/discussions/4832#discussioncomment-13690266 - Ryan Christian

### Local Search Broke

After migrating to Preact, the search box broke because `isImmediatePropagationStopped` wasn't defined. So… I just removed all references to it and hoped for the best, and the search is still usable at least. :+1:

> For some reason after using Preact, `isImmediatePropagationStopped` no longer exists… for now I've added a patch that just removes the function call.
> 
> Seems to be working as intended, so whatever for now! ^-^'
> 
> — https://github.com/svg/svgo.dev/commit/7343911cb22bba12d9c0b25b1974ae63dd000453#r161618434 - Seth Falco

> `isPropogationStopped` and `isImmediatePropagationStopped` are inventions of jQuery that React copied over, I believe. For `/compat`, [we can check `e.cancelBubble` and patch in an `isPropogationStopped` impl](https://github.com/preactjs/preact/blob/2d6811de49ec4b4d6c0820cebf5cfcc4442f2af1/compat/src/render.js#L102), but as far as I'm aware, there's nothing externally visible to support a `isImmediatePropagationStopped` impl.
> 
> — https://github.com/svg/svgo.dev/commit/7343911cb22bba12d9c0b25b1974ae63dd000453#r161629122 - Ryan Christian