### PR TITLE
chore: adopt design tokens

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,9 +1,9 @@
+@import url('tokens.css');
+
 :root {
   --svgo-global-width: 1200px;
   --svgo-pill-bg-color: var(--ifm-color-primary);
   --svgo-pill-fg-color: hsl(0 0% 100%);
-  --svgo-pri-bg-color: hsl(0 0% 100%);
-  --svgo-pri-fg-color: hsl(202 52% 17%);
   --svgo-search-bg-color: var(--svgo-tir-bg-color);
   --svgo-search-bg-hover: hsl(0 0% 86%);
   --svgo-sec-bg-color: hsl(30 10% 96%);
@@ -11,26 +11,24 @@
   --svgo-logo-fg-color: hsl(60 4% 11%);
   --svgo-button-hover-background-color: hsl(202 52% 22%);
 
-  --ifm-background-color: var(--svgo-pri-bg-color) !important;
+  --ifm-background-color: var(--svgo-background) !important;
   --ifm-code-font-size: 95% !important;
   --ifm-color-primary: hsl(217 77% 38%) !important;
   --ifm-container-width-xl: var(--svgo-global-width) !important;
   --ifm-footer-padding-horizontal: 1rem !important;
   --ifm-menu-color: hsl(214 8% 31%) !important;
-  --ifm-navbar-background-color: var(--svgo-pri-bg-color) !important;
+  --ifm-navbar-background-color: var(--svgo-background) !important;
   --ifm-navbar-search-input-placeholder-color: var(--ifm-menu-color) !important;
   --ifm-navbar-shadow: 0 .5rem .5rem 0 hsl(201 61% 10% / 0.1) !important;
   --ifm-tabs-color: var(--ifm-menu-color) !important;
   --ifm-spacing-horizontal: 1rem !important;
   --search-local-hit-background: var(--svgo-sec-bg-color) !important;
 
-  color: var(--svgo-pri-fg-color);
+  color: var(--svgo-foreground);
 
   @media (prefers-color-scheme: dark) {
     --svgo-pill-bg-color: hsl(210 88% 29%);
     --svgo-pill-fg-color: hsl(210 79% 95%);
-    --svgo-pri-bg-color: hsl(203 42% 12%);
-    --svgo-pri-fg-color: hsl(0 0% 100%);
     --svgo-search-bg-hover: hsl(204 13% 45%);
     --svgo-sec-bg-color: hsl(204 41% 18%);
     --svgo-tir-bg-color: hsl(203 13% 40%);
@@ -40,7 +38,7 @@
     --ifm-color-primary: hsl(205 100% 67%) !important;
     --ifm-menu-color: hsl(214 10% 87%) !important;
     --ifm-navbar-shadow: 0 .5rem .5rem 0 hsl(201 61% 10%) !important;
-    --ifm-tabs-color: var(--svgo-pri-fg-color) !important;
+    --ifm-tabs-color: var(--svgo-foreground) !important;
   }
 }
 
@@ -50,8 +48,8 @@
 
 /* Button overrides */
 .button {
-  --ifm-button-color: var(--svgo-pri-bg-color) !important;
-  --ifm-button-background-color: var(--svgo-pri-fg-color) !important;
+  --ifm-button-color: var(--svgo-background) !important;
+  --ifm-button-background-color: var(--svgo-foreground) !important;
 }
 
 .button:hover,
@@ -73,7 +71,7 @@
 
 /* TOC overrides */
 .table-of-contents__link--active {
-  color: var(--svgo-pri-fg-color);
+  color: var(--svgo-foreground);
 }
 
 /* Search overrides */
@@ -92,7 +90,7 @@ nav .navbar__search-input:focus {
 }
 
 nav div kbd {
-  background-color: var(--svgo-pri-bg-color) !important;
+  background-color: var(--svgo-background) !important;
 }
 
 /* Footer overrides */

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -1,0 +1,16 @@
+/**
+ * We don't have a formalized stack getting design tokens from design to
+ * components. We just document and consume design tokens from this file.
+ *
+ * See: https://www.w3.org/community/design-tokens/
+ */
+
+:root {
+  --svgo-background: hsl(0 0% 100%);
+  --svgo-foreground: hsl(202 52% 17%);
+
+  @media (prefers-color-scheme: dark) {
+    --svgo-background: hsl(203 42% 12%);
+    --svgo-foreground: hsl(0 0% 100%);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4536,11 +4536,11 @@ __metadata:
   linkType: hard
 
 "baseline-browser-mapping@npm:^2.8.25":
-  version: 2.10.0
-  resolution: "baseline-browser-mapping@npm:2.10.0"
+  version: 2.10.31
+  resolution: "baseline-browser-mapping@npm:2.10.31"
   bin:
     baseline-browser-mapping: dist/cli.cjs
-  checksum: 10/8145e076e4299f04c7a412e6ea63803e330153cd89c47b5303f9b56b58078f4c3d5a5b5332c1069da889e76facacca4d43f8940375f7e73ce0a4d96214332953
+  checksum: 10/36de39b6df49cc1574cea8c3e719cd92d5852d9a8be35518d490584798a62b383f6b3156d83cd57387173430581526b8ff732953750f74b33aff6afb871dc6cd
   languageName: node
   linkType: hard
 
@@ -4866,9 +4866,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001702, caniuse-lite@npm:^1.0.30001754":
-  version: 1.0.30001756
-  resolution: "caniuse-lite@npm:1.0.30001756"
-  checksum: 10/1aa412f539bf2f3b9120caa6a3552579914cc9de7bc075212d1196e625dc6243317005a45c6aa7675610e5e23d47418564b7b3e7700244005bd665b01625b0ae
+  version: 1.0.30001793
+  resolution: "caniuse-lite@npm:1.0.30001793"
+  checksum: 10/5a1ac39f2f174e86d8320f394a5dfbeab98041722b13d02a21fe47afc2723bc754ea3716a1f276f8462bcbbc3016e82e6f155ebde0881e537af463b5eac1816b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I've been learning about design tokens, and wanted to adopt them in SVGO.dev.

At the end I've included my original proposal in the `<details>`, but I've opted to significantly simplify things by simply using a `tokens.json` file.

To get this merged already, I've scaffolded the minimum of what I think we should do instead based on [How to Build a Design System in a Weekend (For Solo Devs and Small Teams)](https://www.designsystemscollective.com/how-to-build-a-design-system-in-a-weekend-for-solo-devs-and-small-teams-4e82838742ce). This will be expanded on later to use a proper naming convention, store all design tokens, likely including upstream overrides.

<details>
<summary>Old contents of this PR description from when I planned to do a pipeline going from design software → JSON → CSS via styled-dictionary.</summary>

## Publishing Design Documents

We're in the process of migrating from Figma to Penpot. When this transition is done, the Penpot document will be public, and linked somewhere. (Perhaps the README or a contribution guide.)

## Design Tokens Format

We'll only use tooling that supports the latest [Design Tokens Community Group (DTCG)](https://www.w3.org/community/design-tokens/) draft—not any other standard for design tokens. [Penpot](https://penpot.app/collaboration/design-tokens) supports this standard natively, and the [style-dictionary package can convert this format to CSS variables](https://styledictionary.com/reference/hooks/formats/).

I did explore @csstools/postcss-design-tokens too, but this only supports the style-dictionary3 format, which wasn't compatible with the the output from Penpot. Using style-dictionary directly appeared to offer a much better experience anyway in my opinion.

## Proposed Workflow

1. Our designer will now define variables in the design document. (Penpot/Figma)
2. These are exported as "design tokens" to the repository. For now this is done manually by a developer, but we'll investigate if this can be done by the designer directly.
3. Pre-build time, these tokens are converted to CSS variables.
4. During development, we just use these CSS variables as normal.

Before, from my perspective there was no step 1. Meanwhile, step 2 was to open the design and copy and paste discernable variables one-by-one into CSS variables or to hardcode them. It wasn't an awful workflow, but the new workflow seems more streamlined.

<img width="2350" height="860" alt="image" src="https://github.com/user-attachments/assets/662e53af-c340-4575-af4e-7e465b3ef0c1" />

| File | Description | Committed to VCS |
|---|---|---|
| `tokens.json` (left) | Exported design tokens from Penpot. | :heavy_check_mark: |
| `_variables.css` (middle) | CSS variables generated pre-build. | :x: |
| `custom.css` (right) | Consuming the generated CSS variables in our project styles. | :heavy_check_mark: |

**This is a proof of concept—which variables should be tokens and naming conventions for the design tokens have not been defined yet, and we may still reconsider the workflow.**

## How to Contribute?

This gets a little pedantic, but we should consider how this may affect contributing to the repository. This isn't a blocker, but I think it's worth posing the question. Especially if it's worth being explicit that we welcome changes, etc.

The old approach was very contributor friendly, since the repository was a pseudo-source of truth for these CSS variables. Now, the source of truth for these variables reside in a design document, maintained outside the repository—it introduces complexity for contributors who may want to propose design changes.

* Are contributors encouraged to hand edit `~/tokens/tokens.json`? Fortunately, the format is very simple.
* Are there any good development tools for editing token files in popular IDEs?
* Do design tools like Penpot have any native features for proposing changes? Though, we shouldn't assume users would be willing to create an account for this.

No matter what they do in their contribution, it's not a big deal as if approved they can be synced up with the design, or amended before merging (preserving authorship).

I just want to make sure contributors know they're welcome to propose changes, even to `tokens.json`, even though the conventional workflow is that Penpot/Figma is the source of truth for it.

</details>