### PR TITLE
fix: add redirect to new usage path

### DIFF
--- a/docusaurus.config.mjs
+++ b/docusaurus.config.mjs
@@ -46,9 +46,15 @@ const pluginContentPagesOptions = {
 /** @type {import('@docusaurus/plugin-client-redirects').Options} */
 const pluginClientRedirectsOptions = {
   redirects: [
+    // Plugin was renamed
     {
       to: '/docs/plugins/removeScripts/',
       from: '/docs/plugins/removeScriptElement/',
+    },
+    // Mistake in https://github.com/svg/svgo/pull/2038
+    {
+      to: '/docs/usage/usage/',
+      from: '/docs/usage/',
     },
   ],
 };


### PR DESCRIPTION
Just adds a redirect from `/docs/usage/usage/` to `/docs/usage/` which was the intended path for this page.

## Related

* Caused by https://github.com/svg/svgo/pull/2038