### PR TITLE
fix: actually redirect to new usage path

### DIFF
--- a/docusaurus.config.mjs
+++ b/docusaurus.config.mjs
@@ -53,8 +53,8 @@ const pluginClientRedirectsOptions = {
     },
     // Mistake in https://github.com/svg/svgo/pull/2038
     {
-      to: '/docs/usage/usage/',
-      from: '/docs/usage/',
+      to: '/docs/usage/',
+      from: '/docs/usage/usage/',
     },
   ],
 };


### PR DESCRIPTION
Silly mistake, I defined the routes the wrong way around. :facepalm: 

The build passed before because CI run before I merged the paired PR in svg/svgo. :facepalm: :facepalm: 