### PR TITLE
feat: add plausible and privacy section

### DIFF
--- a/docusaurus.config.mjs
+++ b/docusaurus.config.mjs
@@ -271,13 +271,24 @@ const config = {
             {
               label: 'Open Collective',
               href: 'https://opencollective.com/svgo'
-            }
-          ]
-        }
+            },
+            {
+              label: 'Privacy',
+              href: '/privacy',
+            },
+          ],
+        },
       ],
       copyright: `Copyright © ${new Date().getFullYear()} <a href="https://github.com/svg/svgo/graphs/contributors">SVGO and Contributors</a><br>Source Code under MIT · Content and Assets under CC-BY-4.0<br>Designed and Illustrated by <a class="designer-attribution" href="https://vukory.art" target="_blank">Vukory ${VUKORY_SVG}</a>`
     },
   },
+  scripts: [
+    {
+      src: 'https://plausible.falco.fun/js/script.js',
+      defer: true,
+      'data-domain': 'svgo.dev'
+    }
+  ]
 };
 
 export default config;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -5,7 +5,7 @@ import Layout from '@theme/Layout';
 import CopyIcon from '@theme/Icon/Copy';
 import SuccessIcon from '@theme/Icon/Success';
 import Head from '@docusaurus/Head';
-import HomepageFeatures from '../../src/components/HomepageFeatures';
+import HomepageFeatures from '../components/HomepageFeatures';
 import styles from './index.module.css';
 import SvgoTrixie from '../vectors/svgo_trixie.svg';
 

--- a/src/pages/privacy.md
+++ b/src/pages/privacy.md
@@ -1,0 +1,19 @@
+# Privacy Policy
+
+We have **_temporarily_** enabled client-side analytics via [Plausible](https://plausible.io).
+
+Plausible is an Open Source solution that does not use cookies. The server is self-hosted by a maintainer of SVGO—located in the United Kingdom 🇬🇧.
+
+If you're interested in what we see, please review [our Plausible dashboard](https://plausible.falco.fun/svgo.dev). We are keeping the dashboard public for transparency.
+
+If you use an ad blocker such as [uBlock Origin](https://ublockorigin.com), you will be unaffected—we don't hide the fact we use Plausible, and these kinds of extensions will block analytics servers by default. If you are uncomfortable with analytics, we recommend installing uBlock Origin, which will block most client-side analytics across the web.
+
+<h2>Data Collection</h2>
+
+No personal data is collected, no cookies are stored, we don't sell or share data, no data is monetized, etc.
+
+Data collected includes referral sources, top pages, visit duration, information from the devices (device type, operating system, country and browser) used during the visit. Read more in the [Plausible Analytics data policy](https://plausible.io/data-policy).
+
+---
+
+For any questions, please email [Seth Falco](mailto:seth@falco.fun).


### PR DESCRIPTION
This is a little off-brand for me, but I have attempted to do this as ethically as I can.

> Most of what I do is contributed to Open Source projects, **ideally free from** cost, **tracking**, and advertising.
> 
> — https://github.com/SethFalco

We'll be temporarily adding client-side analytics to SVGO.dev using a self-hosting Plausible server. No personal data is collected or stored, no cookies are set, we don't share or sell data, etc. We'll never do anything of the sort!

We'd just like to collect a few aggregate metrics of website usage. I'm expecting to remove this around February 2026. The only reason we wouldn't is if between now and then, we discover significant value in retaining such metrics.

To be fair to users:

1. I've added a privacy page, so users know what's up.
2. I advise users on how they can block the script.
3. This PR is of course being made publically to document the addition.
4. We're publishing the dashboard, so users can see what we see.

## Chore

On the side, I rename a `.js` file to `.jsx`. I noticed this recently, and surprised that the code even worked as I wasn't aware JSX/React components could be written in regular `.js` on server-side.

It should have no impact on the build.