### PR TITLE
chore: disable plausible

### DIFF
--- a/docusaurus.config.mjs
+++ b/docusaurus.config.mjs
@@ -282,14 +282,7 @@ const config = {
       ],
       copyright: `Copyright © ${new Date().getFullYear()} <a href="https://github.com/svg/svgo/graphs/contributors">SVGO and Contributors</a><br>Source Code under MIT · Content and Assets under CC-BY-4.0<br>Designed and Illustrated by <a class="designer-attribution" href="https://vukory.art" target="_blank">Vukory ${VUKORY_SVG}</a>`
     },
-  },
-  scripts: [
-    {
-      src: 'https://plausible.falco.fun/js/script.outbound-links.js',
-      defer: true,
-      'data-domain': 'svgo.dev'
-    }
-  ]
+  }
 };
 
 export default config;


### PR DESCRIPTION
We'll temporarily disable Plausible as the Plausible Analytics server is down.

(The Plausible server is running on my own server, but I'm moving home and the new location does not have an internet connection yet.)