### PR TITLE
chore: add back plausible analytics

### DIFF
--- a/docusaurus.config.mjs
+++ b/docusaurus.config.mjs
@@ -282,7 +282,20 @@ const config = {
       ],
       copyright: `Copyright © ${new Date().getFullYear()} <a href="https://github.com/svg/svgo/graphs/contributors">SVGO and Contributors</a><br>Source Code under MIT · Content and Assets under CC-BY-4.0<br>Designed and Illustrated by <a class="designer-attribution" href="https://vukory.art" target="_blank">Vukory ${VUKORY_SVG}</a>`
     },
-  }
+  },
+  scripts: [
+    {
+      src: 'https://plausible.falco.fun/js/pa-1BMyOcqytxH-H7jJ90MNl.js',
+      async: true
+    }
+  ],
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML: 'window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()'
+    }
+  ]
 };
 
 export default config;


### PR DESCRIPTION
Adds back Plausible using the new SDK API. I had it disabled for a while as I have it self-hosted, and had to take my server down, and I didn't want to host this on a third-party server.

It's back up now though. :+1: 